### PR TITLE
Fix nf rating.

### DIFF
--- a/nf_rating.js
+++ b/nf_rating.js
@@ -30,6 +30,7 @@ if (!$tool.isResponse) {
     if (!IMDbApikey) updateIMDbApikey();
     let obj = JSON.parse($response.body);
     if (consoleLog) console.log("Netflix Original Body:\n" + $response.body);
+    if (typeof(obj.paths[0][1]) == "string") {
     const videoID = obj.paths[0][1];
     const video = obj.value.videos[videoID];
     const map = getTitleMap();
@@ -67,6 +68,9 @@ if (!$tool.isResponse) {
             if (consoleLog) console.log("Netflix Modified Body:\n" + JSON.stringify(obj));
             $done({ body: JSON.stringify(obj) });
         });
+    } else {
+        $done({});
+    }
 }
 
 function getTitleMap() {


### PR DESCRIPTION
When netflix opens, regex may match irrelevant URL, for example the summary cache of multiple teleplay, so it caused script error.