### PR TITLE
增加“京东极速版”、“京喜”、“京东健康”；对于 Quantumult X 特殊处理 $done()。

### DIFF
--- a/jd_price_lite.js
+++ b/jd_price_lite.js
@@ -1,10 +1,13 @@
 /*
 README：https://github.com/yichahucha/surge/tree/master
+^https?://api\.m\.jd\.com/(client\.action|api)\?functionId=(wareBusiness|serverConfig|basicConfig|lite_wareBusiness|pingou_item)
  */
 
 const path1 = "serverConfig";
 const path2 = "wareBusiness";
+const path2h = "wareBusiness.style";
 const path3 = "basicConfig";
+const path4 = "pingou_item";
 const consolelog = false;
 const url = $request.url;
 const body = $response.body;
@@ -21,19 +24,32 @@ if (url.indexOf(path1) != -1) {
 if (url.indexOf(path3) != -1) {
     let obj = JSON.parse(body);
     let JDHttpToolKit = obj.data.JDHttpToolKit;
+    let jCommandConfig = obj.data.jCommandConfig;
     if (JDHttpToolKit) {
         delete obj.data.JDHttpToolKit.httpdns;
         delete obj.data.JDHttpToolKit.dnsvipV6;
     }
+    if (jCommandConfig) {
+		delete obj.data.jCommandConfig.httpdnsConfig;
+	}
     $done({ body: JSON.stringify(obj) });
 }
 
-if (url.indexOf(path2) != -1) {
-    $done({ body });
+if (url.indexOf(path2) != -1 || url.indexOf(path4) != -1) {
+    if (!$tool.isQuanX) {
+        $done({ body });
+    }
     let obj = JSON.parse(body);
     const floors = obj.floors;
     const commodity_info = floors[floors.length - 1];
-    const shareUrl = commodity_info.data.property.shareUrl;
+    const others = obj.others;
+	const domain = obj.domain;
+	const shareUrl =
+		url.indexOf(path4) != -1
+			? domain.h5Url
+			: url.indexOf(path2h) != -1
+			? others.property.shareUrl
+			: commodity_info.data.property.shareUrl;
     request_history_price(shareUrl, function (data) {
         if (data) {
             if (data.ok == 1 && data.single) {
@@ -46,6 +62,7 @@ if (url.indexOf(path2) != -1) {
                 $tool.notify("", "", `⚠️ ${data.msg}`)
             }
         }
+        $done({ body });
     })
 }
 


### PR DESCRIPTION
`lite_wareBusiness` 为 **京东极速版**；  
`pingou_item` 为 **京喜**；  
`wareBusiness.style` 为 **京东健康**（`client.action` 替换为 `api`）；  
`jCommandConfig.httpdnsConfig` 为京喜 app 中的 dns 设置，故删除。  
**Quantumult X** 中 `$done()` 为脚本出口，后续操作不运行，而修改后可能存在接口不稳定同非 lite 版一样的卡 app 行为，故仅对 **Quantumult X** 单独修改。  


需修改正则为：
```properties
^https?://api\.m\.jd\.com/(client\.action|api)\?functionId=(wareBusiness|serverConfig|basicConfig|lite_wareBusiness|pingou_item)
```

感谢大佬在 #80 中的提议。