### PR TITLE
Add support for converting url like jingfen WeChat-MiniApp.

### DIFF
--- a/jd_price_lite.js
+++ b/jd_price_lite.js
@@ -15,6 +15,7 @@ const $tool = tool();
 
 let cookie = $tool.getCache("jfCookie") || "";
 let cscheme = $tool.getCache("jfChooseScheme") || "jd"; // "jx","js","jk" 京东、京喜、京东极速版、京东健康
+let jsapp = [true, "true"].includes($tool.getCache("jfusejsapp")) || false; // 对极速版是否也跳转 app，注意即使跳转 app，也需要先加入购物车返回再结账，否则无法使用极速版优惠券
 let browser = $tool.getCache("chooseBrowser") || "Safari";
 let jfAutoScheme = $tool.getCache("jfAutoScheme"); // 本地不使用 BoxJs 可自行更改 let jfAutoScheme = true / false
 let jfConvert = $tool.getCache("jfUseConvert");
@@ -32,7 +33,10 @@ switch (cscheme) {
         chooseScheme = "openApp.jdHealth";
         break;
     case "js":
-    //chooseScheme = "openjdlite"; // 有问题，极速版暂时跳转浏览器
+        if (jsapp) {
+            chooseScheme = "openjdlite";
+            break;
+        }
     case "browser":
         chooseScheme = "browser";
         break;
@@ -311,7 +315,6 @@ function convert(url, isOriginJXURL) {
             ) {
                 id = url.match(/(\d+)\.html/)[1];
                 url = `https:\/\/item.m.jd.com\/product\/${id}.html`;
-                //url = url.replace(/\//g, "\\/");
             } else if (url.includes("m.jingxi") || url.includes("wq.jd.com")) {
                 id = url.match(/sku=(\d+)/)[1];
                 url = `https:\/\/wq.jd.com\/item\/view?sku=${id}`;
@@ -321,10 +324,10 @@ function convert(url, isOriginJXURL) {
             } else if (url.includes("kpl.m.jd")) {
                 id = url.match(/wareId=(\d+)/)[1];
                 url = `https:\/\/kpl.m.jd.com\/product?wareId=${id}`;
-                //autoScheme = "openjdlite";
-                autoScheme = "browser";
+                autoScheme = jsapp ? "openjdlite" : "browser";
             } else {
                 url = url;
+                //url = url.replace(/\//g, "\\/");
             }
             let body = {
                 funName: "getSuperClickUrl",
@@ -361,25 +364,13 @@ function convert(url, isOriginJXURL) {
                             r.convertURL =
                                 scheme == "browser"
                                     ? chooseBrowser + data.data.promotionUrl
-                                    : `${scheme}://virtual?params=%7B%22category%22:%22jump%22,%22des%22:%22m%22,%22url%22:%22${data.data.promotionUrl}%22%7D`;
-                            /*
-							r.convertURL =
-								autoScheme == "openjdlite"
-									? `${scheme}://virtual?params=%7B%22category%22:%22jump%22,%22des%22:%22productDetail%22,%22skuId%22:%22${id}%22,%22m_param%22:%7B%22ref%22:%22${data.data.promotionUrl}%22%7D%7D`
-									: `${scheme}://virtual?params=%7B%22category%22:%22jump%22,%22des%22:%22m%22,%22url%22:%22${data.data.promotionUrl}%22%7D`;
-							*/
+                                    : `${scheme}://virtual?params=%7B%22category%22:%22jump%22,%22des%22:%22m%22,%22sourceValue%22:%22babel-act%22,%22sourceType%22:%22babel%22,%22url%22:%22${data.data.promotionUrl}%22%7D`;
                         } else {
                             r.msg = `该商品暂无详细返利信息，${data.data.formatContext.trim()}`;
                             r.convertURL =
                                 scheme == "browser"
                                     ? chooseBrowser + data.data.originalContext
-                                    : `${scheme}://virtual?params=%7B%22category%22:%22jump%22,%22des%22:%22m%22,%22url%22:%22${data.data.originalContext}%22%7D`;
-                            /*
-							r.convertURL =
-								autoScheme == "openjdlite"
-									? `${scheme}://virtual?params=%7B%22category%22:%22jump%22,%22des%22:%22productDetail%22,%22skuId%22:%22${id}%22,%22m_param%22:%7B%22ref%22:%22${data.data.originalContext}%22%7D%7D`
-									: `${scheme}://virtual?params=%7B%22category%22:%22jump%22,%22des%22:%22m%22,%22url%22:%22${data.data.originalContext}%22%7D`;
-							*/
+                                    : `${scheme}://virtual?params=%7B%22category%22:%22jump%22,%22des%22:%22m%22,%22sourceValue%22:%22babel-act%22,%22sourceType%22:%22babel%22,%22url%22:%22${data.data.originalContext}%22%7D`;
                         }
                         resolve(r);
                     } else if (data.code === 105) {

--- a/jd_price_lite.js
+++ b/jd_price_lite.js
@@ -13,6 +13,63 @@ const url = $request.url;
 const body = $response.body;
 const $tool = tool();
 
+let cookie = $tool.getCache("jfCookie") || "";
+let cscheme = $tool.getCache("jfChooseScheme") || "jd"; // "jx","js","jk" 京东、京喜、京东极速版、京东健康
+let browser = $tool.getCache("chooseBrowser") || "Safari";
+let jfAutoScheme = $tool.getCache("jfAutoScheme"); // 本地不使用 BoxJs 可自行更改 let jfAutoScheme = true / false
+let jfConvert = $tool.getCache("jfUseConvert");
+
+let chooseScheme;
+let chooseBrowser;
+switch (cscheme) {
+    case "jd":
+        chooseScheme = "openjd";
+        break;
+    case "jx":
+        chooseScheme = "openapp.jdpingou";
+        break;
+    case "jk":
+        chooseScheme = "openApp.jdHealth";
+        break;
+    case "js":
+    //chooseScheme = "openjdlite"; // 有问题，极速版暂时跳转浏览器
+    case "browser":
+        chooseScheme = "browser";
+        break;
+}
+switch (browser) {
+    case "Safari":
+        chooseBrowser = "";
+        break;
+    case "Alook":
+        chooseBrowser = "Alook://";
+        break;
+    default:
+        chooseBrowser = $tool.getCache("jfDIYScheme");
+}
+const autoChoose = jfAutoScheme == undefined ? true : [true, "true"].includes(jfAutoScheme);
+const useConvert = jfAutoScheme == undefined ? true : [true, "true"].includes(jfConvert);
+let autoScheme;
+let cookiesArr = [
+    $tool.getCache("CookieJD"),
+    $tool.getCache("CookieJD2"),
+    ...cookieParse($tool.getCache("CookiesJD") || "[]").map((item) => item.cookie),
+].filter((item) => !!item);
+
+function cookieParse(str) {
+    if (typeof str == "string") {
+        try {
+            return JSON.parse(str);
+        } catch (e) {
+            console.log(e);
+            $.msg($.name, "", "请勿随意在BoxJs输入框修改内容\n建议通过脚本去获取cookie");
+            return [];
+        }
+    }
+}
+
+cookie = cookie ? cookie : cookiesArr[0];
+
 if (url.indexOf(path1) != -1) {
     let obj = JSON.parse(body);
     delete obj.serverConfig.httpdns;
@@ -30,8 +87,8 @@ if (url.indexOf(path3) != -1) {
         delete obj.data.JDHttpToolKit.dnsvipV6;
     }
     if (jCommandConfig) {
-		delete obj.data.jCommandConfig.httpdnsConfig;
-	}
+        delete obj.data.jCommandConfig.httpdnsConfig;
+    }
     $done({ body: JSON.stringify(obj) });
 }
 
@@ -43,57 +100,73 @@ if (url.indexOf(path2) != -1 || url.indexOf(path4) != -1) {
     const floors = obj.floors;
     const commodity_info = floors[floors.length - 1];
     const others = obj.others;
-	const domain = obj.domain;
-	const shareUrl =
-		url.indexOf(path4) != -1
-			? domain.h5Url
-			: url.indexOf(path2h) != -1
-			? others.property.shareUrl
-			: commodity_info.data.property.shareUrl;
-    request_history_price(shareUrl, function (data) {
-        if (data) {
-            if (data.ok == 1 && data.single) {
-                const lower = lowerMsgs(data.single)
-                const detail = priceSummary(data)
-                const tip = data.PriceRemark.Tip
-                $tool.notify("", "", `${lower}\n${tip}${detail}`)
+    const domain = obj.domain;
+    const shareUrl =
+        url.indexOf(path4) != -1
+            ? domain.h5Url
+            : url.indexOf(path2h) != -1
+            ? others.property.shareUrl
+            : commodity_info.data.property.shareUrl;
+    autoScheme = url.indexOf(path2h) != -1 ? "openApp.jdHealth" : "openjd";
+    //const scheme = !autoChoose ? chooseScheme : url.indexOf(path4) != -1 ? "openapp.jdpingou" : url.indexOf(path2h) != -1 ? "openApp.jdHealth" : url.indexOf("lite_"+path3) != -1 ? "openjdlite" : "openjd";
+    let getHistory = request_history_price(shareUrl);
+    let convertURL = "";
+    let jxconvertURL = "";
+    if (useConvert) {
+        convertURL = convert(shareUrl);
+        jxconvertURL = url.indexOf(path4) != -1 ? convert(shareUrl, true) : undefined;
+    }
+    Promise.all([getHistory, convertURL, jxconvertURL])
+        .then((detail) => {
+            let msg = "";
+            if (detail[1] == "useJXOrigin") detail[1] = detail[2];
+            if (detail[0].lower_tip) {
+                msg += detail[0].lower_tip;
+                let convertmsg = detail[1].convertURL ? detail[1].msg : detail[1];
+                msg += convertmsg ? "\n" + convertmsg : "";
+                msg += "\n" + detail[0].historydetail;
+            } else {
+                let convertmsg = detail[1].convertURL ? detail[1].msg : detail[1];
+                msg += convertmsg ? convertmsg + "\n" : "";
+                msg += detail[0];
             }
-            if (data.ok == 0 && data.msg.length > 0) {
-                $tool.notify("", "", `⚠️ ${data.msg}`)
-            }
-        }
-        $done({ body });
-    })
+            let oprnUrl = detail[1].convertURL ? detail[1].convertURL : "";
+            $tool.notify("", "", msg, oprnUrl);
+        })
+        .finally(() => {
+            $done({ body });
+        });
 }
 
 function lowerMsgs(data) {
-    const lower = data.lowerPriceyh
-    const lowerDate = dateFormat(data.lowerDateyh)
-    const lowerMsg = "🍵 历史最低到手价：¥" + String(lower) + ` (${lowerDate}) `
-    return lowerMsg
+    const lower = data.lowerPriceyh;
+    const lowerDate = dateFormat(data.lowerDateyh);
+    const lowerMsg = "🍵 历史最低到手价：¥" + String(lower) + ` (${lowerDate}) `;
+    return lowerMsg;
 }
 
-
 function priceSummary(data) {
-    let summary = ""
-    let listPriceDetail = data.PriceRemark.ListPriceDetail.slice(0,4)
-    let list = listPriceDetail.concat(historySummary(data.single))
+    let summary = "";
+    let listPriceDetail = data.PriceRemark.ListPriceDetail.slice(0, 4);
+    let list = listPriceDetail.concat(historySummary(data.single));
     list.forEach((item, index) => {
         if (item.Name == "双11价格") {
-            item.Name = "双十一价格"
+            item.Name = "双十一价格";
         } else if (item.Name == "618价格") {
-            item.Name = "六一八价格"
+            item.Name = "六一八价格";
         }
         let price = String(parseInt(item.Price.substr(1)));
-        summary += `\n${item.Name}   ${isNaN(price) ? "-" : "¥" + price}   ${item.Date}   ${item.Difference}`
-    })
-    return summary
+        summary += `\n${item.Name}   ${isNaN(price) ? "-" : "¥" + price}   ${item.Date}   ${
+            item.Difference
+        }`;
+    });
+    return summary;
 }
 
 function historySummary(single) {
     const rexMatch = /\[.*?\]/g;
     const rexExec = /\[(.*),(.*),"(.*)".*\]/;
-    let currentPrice, lowest30, lowest90, lowest180, lowest360
+    let currentPrice, lowest30, lowest90, lowest180, lowest360;
     let list = single.jiagequshiyh.match(rexMatch);
     list = list.reverse().slice(0, 360);
     list.forEach((item, index) => {
@@ -103,35 +176,59 @@ function historySummary(single) {
             const date = dateUTC.format("yyyy-MM-dd");
             let price = parseFloat(result[2]);
             if (index == 0) {
-                currentPrice = price
-                lowest30 = { Name: "三十天最低", Price: `¥${String(price)}`, Date: date, Difference: difference(currentPrice, price), price }
-                lowest90 = { Name: "九十天最低", Price: `¥${String(price)}`, Date: date, Difference: difference(currentPrice, price), price }
-                lowest180 = { Name: "一百八最低", Price: `¥${String(price)}`, Date: date, Difference: difference(currentPrice, price), price }
-                lowest360 = { Name: "三百六最低", Price: `¥${String(price)}`, Date: date, Difference: difference(currentPrice, price), price }
+                currentPrice = price;
+                lowest30 = {
+                    Name: "三十天最低",
+                    Price: `¥${String(price)}`,
+                    Date: date,
+                    Difference: difference(currentPrice, price),
+                    price,
+                };
+                lowest90 = {
+                    Name: "九十天最低",
+                    Price: `¥${String(price)}`,
+                    Date: date,
+                    Difference: difference(currentPrice, price),
+                    price,
+                };
+                lowest180 = {
+                    Name: "一百八最低",
+                    Price: `¥${String(price)}`,
+                    Date: date,
+                    Difference: difference(currentPrice, price),
+                    price,
+                };
+                lowest360 = {
+                    Name: "三百六最低",
+                    Price: `¥${String(price)}`,
+                    Date: date,
+                    Difference: difference(currentPrice, price),
+                    price,
+                };
             }
             if (index < 30 && price < lowest30.price) {
-                lowest30.price = price
-                lowest30.Price = `¥${String(price)}`
-                lowest30.Date = date
-                lowest30.Difference = difference(currentPrice, price)
+                lowest30.price = price;
+                lowest30.Price = `¥${String(price)}`;
+                lowest30.Date = date;
+                lowest30.Difference = difference(currentPrice, price);
             }
             if (index < 90 && price < lowest90.price) {
-                lowest90.price = price
-                lowest90.Price = `¥${String(price)}`
-                lowest90.Date = date
-                lowest90.Difference = difference(currentPrice, price)
+                lowest90.price = price;
+                lowest90.Price = `¥${String(price)}`;
+                lowest90.Date = date;
+                lowest90.Difference = difference(currentPrice, price);
             }
             if (index < 180 && price < lowest180.price) {
-                lowest180.price = price
-                lowest180.Price = `¥${String(price)}`
-                lowest180.Date = date
-                lowest180.Difference = difference(currentPrice, price)
+                lowest180.price = price;
+                lowest180.Price = `¥${String(price)}`;
+                lowest180.Date = date;
+                lowest180.Difference = difference(currentPrice, price);
             }
             if (index < 360 && price < lowest360.price) {
-                lowest360.price = price
-                lowest360.Price = `¥${String(price)}`
-                lowest360.Date = date
-                lowest360.Difference = difference(currentPrice, price)
+                lowest360.price = price;
+                lowest360.Price = `¥${String(price)}`;
+                lowest360.Date = date;
+                lowest360.Difference = difference(currentPrice, price);
             }
         }
     });
@@ -139,11 +236,11 @@ function historySummary(single) {
 }
 
 function difference(currentPrice, price) {
-    let difference = sub(currentPrice, price)
+    let difference = sub(currentPrice, price);
     if (difference == 0) {
-        return "-"
+        return "-";
     } else {
-        return `${difference > 0 ? "↑" : "↓"}${String(difference)}`
+        return `${difference > 0 ? "↑" : "↓"}${String(difference)}`;
     }
 }
 
@@ -152,33 +249,155 @@ function sub(arg1, arg2) {
 }
 
 function add(arg1, arg2) {
-    arg1 = arg1.toString(), arg2 = arg2.toString();
-    var arg1Arr = arg1.split("."), arg2Arr = arg2.split("."), d1 = arg1Arr.length == 2 ? arg1Arr[1] : "", d2 = arg2Arr.length == 2 ? arg2Arr[1] : "";
+    (arg1 = arg1.toString()), (arg2 = arg2.toString());
+    var arg1Arr = arg1.split("."),
+        arg2Arr = arg2.split("."),
+        d1 = arg1Arr.length == 2 ? arg1Arr[1] : "",
+        d2 = arg2Arr.length == 2 ? arg2Arr[1] : "";
     var maxLen = Math.max(d1.length, d2.length);
     var m = Math.pow(10, maxLen);
     var result = Number(((arg1 * m + arg2 * m) / m).toFixed(maxLen));
     var d = arguments[2];
-    return typeof d === "number" ? Number((result).toFixed(d)) : result;
+    return typeof d === "number" ? Number(result.toFixed(d)) : result;
 }
 
-function request_history_price(share_url, callback) {
-    const options = {
-        url: "https://apapia-history.manmanbuy.com/ChromeWidgetServices/WidgetServices.ashx",
-        headers: {
-            "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-            "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 - mmbWebBrowse - ios"
-        },
-        body: "methodName=getHistoryTrend&p_url=" + encodeURIComponent(share_url)
-    }
-    $tool.post(options, function (error, response, data) {
-        if (!error) {
-            callback(JSON.parse(data));
-            if (consolelog) console.log("Data:\n" + data);
+function request_history_price(share_url) {
+    return new Promise((resolve) => {
+        let options = {
+            url: "https://apapia-history.manmanbuy.com/ChromeWidgetServices/WidgetServices.ashx",
+            headers: {
+                "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+                "User-Agent":
+                    "Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 - mmbWebBrowse - ios",
+            },
+            body: "methodName=getHistoryTrend&p_url=" + encodeURIComponent(share_url),
+        };
+        $tool.post(options, function (error, response, data) {
+            if (!error) {
+                data = JSON.parse(data);
+                if (consolelog) console.log("Data:\n" + data);
+                if (data.ok == 1 && data.single) {
+                    const lower = lowerMsgs(data.single);
+                    const detail = priceSummary(data);
+                    const tip = data.PriceRemark.Tip;
+                    let r = {};
+                    r.lower_tip = `${lower} ${tip}`;
+                    r.historydetail = `${detail.substr(1)}`;
+                    resolve(r);
+                }
+                if (data.ok == 0 && data.msg.length > 0) {
+                    let e = `⚠️ ${data.msg}`;
+                    resolve(e);
+                }
+            } else {
+                if (consolelog) console.log("JD History Error:\n" + error);
+                resolve();
+            }
+        });
+    });
+}
+
+function convert(url, isOriginJXURL) {
+    return new Promise((resolve) => {
+        if (!cookiesArr[0]) {
+            $tool.setCache("false", "jfUseConvert");
+            resolve("");
         } else {
-            callback(null, null);
-            if (consolelog) console.log("Error:\n" + error);
+            let id;
+            if (
+                url.includes("item.m.jd") ||
+                url.includes("item.jd") ||
+                (!autoChoose && chooseScheme == "openApp.jdHealth")
+            ) {
+                id = url.match(/(\d+)\.html/)[1];
+                url = `https:\/\/item.m.jd.com\/product\/${id}.html`;
+                //url = url.replace(/\//g, "\\/");
+            } else if (url.includes("m.jingxi") || url.includes("wq.jd.com")) {
+                id = url.match(/sku=(\d+)/)[1];
+                url = `https:\/\/wq.jd.com\/item\/view?sku=${id}`;
+                if (isOriginJXURL || (!autoChoose && chooseScheme == "openjdlite"))
+                    url = `https:\/\/m.jingxi.com\/item\/jxview?sku=${id}`;
+                autoScheme = "openapp.jdpingou";
+            } else if (url.includes("kpl.m.jd")) {
+                id = url.match(/wareId=(\d+)/)[1];
+                url = `https:\/\/kpl.m.jd.com\/product?wareId=${id}`;
+                //autoScheme = "openjdlite";
+                autoScheme = "browser";
+            } else {
+                url = url;
+            }
+            let body = {
+                funName: "getSuperClickUrl",
+                param: {
+                    materialInfo: url,
+                    ext1: "200|100_3|",
+                },
+            };
+            let t = +new Date();
+            let options = {
+                url: `https://api.m.jd.com/api?functionId=ConvertSuperLink&appid=u&_=${t}&body=${encodeURI(
+                    JSON.stringify(body)
+                )}&loginType=2`,
+                headers: {
+                    "Accept-Encoding": "gzip,compress,br,deflate",
+                    Connection: "keep-alive",
+                    Cookie: cookie,
+                    Host: "api.m.jd.com",
+                    Referer: "https://servicewechat.com/wxf463e50cd384beda/114/page-frame.html",
+                    "User-Agent":
+                        "Mozilla/5.0 (iPhone; CPU iPhone OS 13_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 MicroMessenger/8.0.4(0x18000429) NetType/WIFI Language/zh_CN",
+                    "content-type": "application/json",
+                },
+            };
+            $tool.get(options, function (err, resp, data) {
+                if (!err) {
+                    data = JSON.parse(data);
+                    console.log("JD Convert Data:\n" + data);
+                    if (data.code === 200) {
+                        let r = {};
+                        let scheme = autoChoose ? autoScheme : chooseScheme;
+                        if (data.data.promotionUrl) {
+                            r.msg = `💰返点比率：${data.data.wlCommissionShare} %    预计返利：¥ ${data.data.wlCommission}`;
+                            r.convertURL =
+                                scheme == "browser"
+                                    ? chooseBrowser + data.data.promotionUrl
+                                    : `${scheme}://virtual?params=%7B%22category%22:%22jump%22,%22des%22:%22m%22,%22url%22:%22${data.data.promotionUrl}%22%7D`;
+                            /*
+							r.convertURL =
+								autoScheme == "openjdlite"
+									? `${scheme}://virtual?params=%7B%22category%22:%22jump%22,%22des%22:%22productDetail%22,%22skuId%22:%22${id}%22,%22m_param%22:%7B%22ref%22:%22${data.data.promotionUrl}%22%7D%7D`
+									: `${scheme}://virtual?params=%7B%22category%22:%22jump%22,%22des%22:%22m%22,%22url%22:%22${data.data.promotionUrl}%22%7D`;
+							*/
+                        } else {
+                            r.msg = `该商品暂无详细返利信息，${data.data.formatContext.trim()}`;
+                            r.convertURL =
+                                scheme == "browser"
+                                    ? chooseBrowser + data.data.originalContext
+                                    : `${scheme}://virtual?params=%7B%22category%22:%22jump%22,%22des%22:%22m%22,%22url%22:%22${data.data.originalContext}%22%7D`;
+                            /*
+							r.convertURL =
+								autoScheme == "openjdlite"
+									? `${scheme}://virtual?params=%7B%22category%22:%22jump%22,%22des%22:%22productDetail%22,%22skuId%22:%22${id}%22,%22m_param%22:%7B%22ref%22:%22${data.data.originalContext}%22%7D%7D`
+									: `${scheme}://virtual?params=%7B%22category%22:%22jump%22,%22des%22:%22m%22,%22url%22:%22${data.data.originalContext}%22%7D`;
+							*/
+                        }
+                        resolve(r);
+                    } else if (data.code === 105) {
+                        if (autoScheme == "openapp.jdpingou") resolve("useJXOrigin");
+                        else resolve("");
+                    } else if (data.code === 430) {
+                        $tool.setCache("false", "jfUseConvert");
+                        resolve("");
+                    } else {
+                        resolve(JSON.stringify(data));
+                    }
+                } else {
+                    console.log("JD Convert Error:\n" + err);
+                    resolve();
+                }
+            });
         }
-    })
+    });
 }
 
 function dateFormat(cellval) {
@@ -189,74 +408,109 @@ function dateFormat(cellval) {
 }
 
 function tool() {
-    const isSurge = typeof $httpClient != "undefined"
-    const isQuanX = typeof $task != "undefined"
+    const isSurge = typeof $httpClient != "undefined";
+    const isQuanX = typeof $task != "undefined";
     const node = (() => {
         if (typeof require == "function") {
-            const request = require('request')
-            return ({ request })
+            const request = require("request");
+            return { request };
         } else {
-            return (null)
+            return null;
         }
-    })()
-    const notify = (title, subtitle, message) => {
-        if (isQuanX) $notify(title, subtitle, message)
-        if (isSurge) $notification.post(title, subtitle, message)
-        if (node) console.log(JSON.stringify({ title, subtitle, message }));
-    }
+    })();
+    const notify = (title, subtitle, content, open_url) => {
+        if (isSurge) {
+            let opts = {};
+            if (open_url) opts["url"] = open_url;
+            if (JSON.stringify(opts) == "{}") {
+                $notification.post(title, subtitle, content);
+            } else {
+                $notification.post(title, subtitle, content, opts);
+            }
+        }
+        if (isQuanX) {
+            let opts = {};
+            if (open_url) opts["open-url"] = open_url;
+            if (JSON.stringify(opts) == "{}") {
+                $notify(title, subtitle, content);
+            } else {
+                $notify(title, subtitle, content, opts);
+            }
+        }
+        if (isLoon) {
+            let opts = {};
+            if (open_url) opts["openUrl"] = open_url;
+            if (JSON.stringify(opts) == "{}") {
+                $notification.post(title, subtitle, content);
+            } else {
+                $notification.post(title, subtitle, content, opts);
+            }
+        }
+        if (node) {
+            let content_Node = content + (open_url == undefined ? "" : `\n\n跳转链接：${open_url}`);
+            console.log(`${title}\n${subtitle}\n${content_Node}\n\n`);
+        }
+    };
     const setCache = (value, key) => {
-        if (isQuanX) return $prefs.setValueForKey(value, key)
-        if (isSurge) return $persistentStore.write(value, key)
-    }
+        if (isQuanX) return $prefs.setValueForKey(value, key);
+        if (isSurge) return $persistentStore.write(value, key);
+    };
     const getCache = (key) => {
-        if (isQuanX) return $prefs.valueForKey(key)
-        if (isSurge) return $persistentStore.read(key)
-    }
+        if (isQuanX) return $prefs.valueForKey(key);
+        if (isSurge) return $persistentStore.read(key);
+    };
     const adapterStatus = (response) => {
         if (response.status) {
-            response["statusCode"] = response.status
+            response["statusCode"] = response.status;
         } else if (response.statusCode) {
-            response["status"] = response.statusCode
+            response["status"] = response.statusCode;
         }
-        return response
-    }
+        return response;
+    };
     const get = (options, callback) => {
         if (isQuanX) {
-            if (typeof options == "string") options = { url: options }
-            options["method"] = "GET"
-            $task.fetch(options).then(response => {
-                callback(null, adapterStatus(response), response.body)
-            }, reason => callback(reason.error, null, null))
+            if (typeof options == "string") options = { url: options };
+            options["method"] = "GET";
+            $task.fetch(options).then(
+                (response) => {
+                    callback(null, adapterStatus(response), response.body);
+                },
+                (reason) => callback(reason.error, null, null)
+            );
         }
-        if (isSurge) $httpClient.get(options, (error, response, body) => {
-            callback(error, adapterStatus(response), body)
-        })
+        if (isSurge)
+            $httpClient.get(options, (error, response, body) => {
+                callback(error, adapterStatus(response), body);
+            });
         if (node) {
             node.request(options, (error, response, body) => {
-                callback(error, adapterStatus(response), body)
-            })
+                callback(error, adapterStatus(response), body);
+            });
         }
-    }
+    };
     const post = (options, callback) => {
         if (isQuanX) {
-            if (typeof options == "string") options = { url: options }
-            options["method"] = "POST"
-            $task.fetch(options).then(response => {
-                callback(null, adapterStatus(response), response.body)
-            }, reason => callback(reason.error, null, null))
+            if (typeof options == "string") options = { url: options };
+            options["method"] = "POST";
+            $task.fetch(options).then(
+                (response) => {
+                    callback(null, adapterStatus(response), response.body);
+                },
+                (reason) => callback(reason.error, null, null)
+            );
         }
         if (isSurge) {
             $httpClient.post(options, (error, response, body) => {
-                callback(error, adapterStatus(response), body)
-            })
+                callback(error, adapterStatus(response), body);
+            });
         }
         if (node) {
             node.request.post(options, (error, response, body) => {
-                callback(error, adapterStatus(response), body)
-            })
+                callback(error, adapterStatus(response), body);
+            });
         }
-    }
-    return { isQuanX, isSurge, notify, setCache, getCache, get, post }
+    };
+    return { isQuanX, isSurge, notify, setCache, getCache, get, post };
 }
 
 Array.prototype.insert = function (index, item) {
@@ -272,22 +526,23 @@ Date.prototype.format = function (fmt) {
         "m+": this.getMinutes(),
         "s+": this.getSeconds(),
         "q+": Math.floor((this.getMonth() + 3) / 3),
-        "S+": this.getMilliseconds()
+        "S+": this.getMilliseconds(),
     };
     for (var k in o) {
         if (new RegExp("(" + k + ")").test(fmt)) {
             if (k == "y+") {
                 fmt = fmt.replace(RegExp.$1, ("" + o[k]).substr(4 - RegExp.$1.length));
-            }
-            else if (k == "S+") {
+            } else if (k == "S+") {
                 var lens = RegExp.$1.length;
                 lens = lens == 1 ? 3 : lens;
                 fmt = fmt.replace(RegExp.$1, ("00" + o[k]).substr(("" + o[k]).length - 1, lens));
-            }
-            else {
-                fmt = fmt.replace(RegExp.$1, (RegExp.$1.length == 1) ? (o[k]) : (("00" + o[k]).substr(("" + o[k]).length)));
+            } else {
+                fmt = fmt.replace(
+                    RegExp.$1,
+                    RegExp.$1.length == 1 ? o[k] : ("00" + o[k]).substr(("" + o[k]).length)
+                );
             }
         }
     }
     return fmt;
-}
+};

--- a/jd_price_lite.js
+++ b/jd_price_lite.js
@@ -303,7 +303,7 @@ function request_history_price(share_url) {
 
 function convert(url, isOriginJXURL) {
     return new Promise((resolve) => {
-        if (!cookiesArr[0]) {
+        if (!cookie) {
             $tool.setCache("false", "jfUseConvert");
             resolve("");
         } else {

--- a/jd_price_lite.js
+++ b/jd_price_lite.js
@@ -1,5 +1,6 @@
 /*
 README：https://github.com/yichahucha/surge/tree/master
+BoxJs: https://raw.githubusercontent.com/zZPiglet/surge/master/jf_boxjs.json
 ^https?://api\.m\.jd\.com/(client\.action|api)\?functionId=(wareBusiness|serverConfig|basicConfig|lite_wareBusiness|pingou_item)
  */
 

--- a/jd_price_lite.js
+++ b/jd_price_lite.js
@@ -8,7 +8,6 @@ const path2 = "wareBusiness";
 const path2h = "wareBusiness.style";
 const path3 = "basicConfig";
 const path4 = "pingou_item";
-const consolelog = false;
 const url = $request.url;
 const body = $response.body;
 const $tool = tool();
@@ -279,7 +278,7 @@ function request_history_price(share_url) {
         $tool.post(options, function (error, response, data) {
             if (!error) {
                 data = JSON.parse(data);
-                if (consolelog) console.log("Data:\n" + data);
+                console.log("Data:\n" + data);
                 if (data.ok == 1 && data.single) {
                     const lower = lowerMsgs(data.single);
                     const detail = priceSummary(data);
@@ -294,7 +293,7 @@ function request_history_price(share_url) {
                     resolve(e);
                 }
             } else {
-                if (consolelog) console.log("JD History Error:\n" + error);
+                console.log("JD History Error:\n" + error);
                 resolve();
             }
         });
@@ -399,7 +398,8 @@ function dateFormat(cellval) {
 }
 
 function tool() {
-    const isSurge = typeof $httpClient != "undefined";
+    const isSurge = typeof $utils != "undefined";
+    const isLoon = typeof $loon != "undefined";
     const isQuanX = typeof $task != "undefined";
     const node = (() => {
         if (typeof require == "function") {

--- a/jf_boxjs.json
+++ b/jf_boxjs.json
@@ -9,7 +9,7 @@
         "id": "jf",
         "name": "京粉转链",
         "desc": "在京东比价中增加京粉转链，如显示有转链信息（即使显示无详细返利信息）则可点击跳转跟单，如未显示返利信息则为未参加推广的商品，不会跳转。",
-        "keys": ["jfCookie", "jfUseConvert", "jfAutoScheme", "jfChooseScheme", "chooseBrowser", "jfDIYScheme"],
+        "keys": ["jfCookie", "jfUseConvert", "jfAutoScheme", "jfusejsapp", "jfChooseScheme", "chooseBrowser", "jfDIYScheme"],
         "settings": [
           {
             "id": "jfUseConvert",
@@ -35,9 +35,16 @@
                 { "key": "jd", "label": "京东" },
                 { "key": "jx", "label": "京喜" },
                 { "key": "jk", "label": "京东健康" }, 
-                { "key": "js", "label": "京东极速版（暂不可用，极速版默认同浏览器设置）" },
+                { "key": "js", "label": "京东极速版" },
                 { "key": "browser", "label": "浏览器" }
             ]
+          },
+          {
+            "id": "jfusejsapp",
+            "name": "京东极速版使用 app",
+            "val": false,
+            "type": "boolean",
+            "desc": "开启时对目标为京东极速版则跳转京东极速版，关闭则跳转浏览器，默认关闭。注意：即使开启，由于极速版 URL Scheme 问题，跳转后只能先加入购物车，返回原购物车界面进行结账，否则无法使用极速版优惠券。"
           },
           {
             "id": "chooseBrowser",

--- a/jf_boxjs.json
+++ b/jf_boxjs.json
@@ -1,0 +1,81 @@
+{
+    "id": "jfConvert",
+    "name": "京粉转链",
+    "author": "@jfConvert",
+    "icon": "https://is5-ssl.mzstatic.com/image/thumb/Purple125/v4/eb/a8/f6/eba8f63a-b550-4586-b5d3-f22c0718ef81/source/100x100bb.jpg",
+    "repo": "https://jingfen.jd.com/html/index.html",
+    "apps": [
+      {
+        "id": "jf",
+        "name": "京粉转链",
+        "desc": "在京东比价中增加京粉转链，如显示有转链信息（即使显示无详细返利信息）则可点击跳转跟单，如未显示返利信息则为未参加推广的商品，不会跳转。",
+        "keys": ["jfCookie", "jfUseConvert", "jfAutoScheme", "jfChooseScheme", "chooseBrowser", "jfDIYScheme"],
+        "settings": [
+          {
+            "id": "jfUseConvert",
+            "name": "开启转链",
+            "val": true,
+            "type": "boolean",
+            "desc": "是否开启京粉转链？"
+          },
+          {
+            "id": "jfAutoScheme",
+            "name": "自动目标",
+            "val": true,
+            "type": "boolean",
+            "desc": "开启后如转链成功有返利，点击通知跳转正在使用的 app，关闭则跳转自选的 app。"
+          },
+          {
+            "id": "jfChooseScheme",
+            "name": "自选目标",
+            "val": "jd",
+            "type": "radios",
+            "desc": "自选跳转的 app，仅在自动目标关闭时有效。",
+            "items": [
+                { "key": "jd", "label": "京东" },
+                { "key": "jx", "label": "京喜" },
+                { "key": "jk", "label": "京东健康" }, 
+                { "key": "js", "label": "京东极速版（暂不可用，极速版默认同浏览器设置）" },
+                { "key": "browser", "label": "浏览器" }
+            ]
+          },
+          {
+            "id": "chooseBrowser",
+            "name": "浏览器目标",
+            "val": "Safari",
+            "type": "radios",
+            "desc": "自选跳转的浏览器。",
+            "items": [
+                { "key": "Safari", "label": "Safari" },
+                { "key": "Alook", "label": "Alook" },
+                { "key": "DIY", "label": "自定义" }
+            ]
+          },
+          {
+            "id": "jfDIYScheme",
+            "name": "自定义浏览器",
+            "val": "",
+            "type": "textarea",
+            "placeholder": "Foxok://url?", 
+            "autoGrow": true,
+            "rows": 2,
+            "desc": "自定义跳转浏览器 URL Scheme，拼接后会是 diy+convertURL，如 Foxok://url?convertURL"
+          },
+          {
+            "id": "jfCookie",
+            "name": "Cookie",
+            "type": "textarea",
+            "autoGrow": true,
+            "rows": 2,
+            "desc": "使用京粉的京东账号 Cookie，如不填则为京东系脚本中的第一个 Cookie。"
+          }
+        ],
+        "author": "@jfConvert",
+        "repo": "https://jingfen.jd.com/html/index.html",
+        "icons": [
+          "https://is5-ssl.mzstatic.com/image/thumb/Purple125/v4/eb/a8/f6/eba8f63a-b550-4586-b5d3-f22c0718ef81/source/100x100bb.jpg",
+          "https://is5-ssl.mzstatic.com/image/thumb/Purple125/v4/eb/a8/f6/eba8f63a-b550-4586-b5d3-f22c0718ef81/source/100x100bb.jpg"
+        ]
+      }
+    ]
+  }

--- a/loon_sub.conf
+++ b/loon_sub.conf
@@ -1,6 +1,6 @@
-http-request ^https?://ios\.prod\.ftl\.netflix\.com/iosui/user/.+path=%5B%22videos%22%2C%\d+%22%2C%22summary%22%5D script-path=https://raw.githubusercontent.com/yichahucha/surge/master/nf_rating.js, tag=奈飞评分1
-http-response ^https?://ios\.prod\.ftl\.netflix\.com/iosui/user/.+path=%5B%22videos%22%2C%\d+%22%2C%22summary%22%5D requires-body=1,script-path=https://raw.githubusercontent.com/yichahucha/surge/master/nf_rating.js, tag=奈飞评分2
-http-response ^https?://ios\.prod\.ftl\.netflix\.com/iosui/warmer/.+type=show-ath requires-body=1,max-size=0,script-path=https://raw.githubusercontent.com/yichahucha/surge/master/nf_rating_season.js, tag=单集评分
+http-request ^https?://ios-h2\.prod\.ftl\.netflix\.com/iosui/user/.+path=%5B%22videos%22%2C%\d+%22%2C%22summary%22%5D script-path=https://raw.githubusercontent.com/yichahucha/surge/master/nf_rating.js, tag=奈飞评分1
+http-response ^https?://ios-h2\.prod\.ftl\.netflix\.com/iosui/user/.+path=%5B%22videos%22%2C%\d+%22%2C%22summary%22%5D requires-body=1,script-path=https://raw.githubusercontent.com/yichahucha/surge/master/nf_rating.js, tag=奈飞评分2
+http-response ^https?://ios-h2\.prod\.ftl\.netflix\.com/iosui/warmer/.+type=show-ath requires-body=1,max-size=0,script-path=https://raw.githubusercontent.com/yichahucha/surge/master/nf_rating_season.js, tag=单集评分
 http-response ^https?://(sdk|wb)app\.uve\.weibo\.com(/interface/sdk/sdkad.php|/wbapplua/wbpullad.lua) requires-body=1,script-path=https://raw.githubusercontent.com/yichahucha/surge/master/wb_launch.js, tag=微博去广告
 http-response ^https?://m?api\.weibo\.c(n|om)/2/(statuses/(unread|extend|positives/get|(friends|video)(/|_)(mix)?timeline)|stories/(video_stream|home_list)|(groups|fangle)/timeline|profile/statuses|comments/build_comments|photo/recommend_list|service/picfeed|searchall|cardlist|page|!/(photos/pic_recommend_status|live/media_homelist)|video/tiny_stream_video_list|photo/info) requires-body=1,max-size=-1,script-path=https://raw.githubusercontent.com/yichahucha/surge/master/wb_ad.js, , tag=微博去广告
 http-response ^https?://api\.m\.jd\.com/client\.action\?functionId=(wareBusiness|serverConfig|basicConfig) requires-body=1,script-path=https://raw.githubusercontent.com/yichahucha/surge/master/jd_price.js,tag=京东比价
@@ -9,4 +9,4 @@ http-response ^https?://trade-acs\.m\.taobao\.com/gw/mtop\.taobao\.detail\.getde
 http-request ^http://.+/amdc/mobileDispatch requires-body=1,script-path=https://raw.githubusercontent.com/yichahucha/surge/master/tb_price_lite.js,tag=淘宝比价1 Lite(通知版)
 http-response ^https?://trade-acs\.m\.taobao\.com/gw/mtop\.taobao\.detail\.getdetail requires-body=1,script-path=https://raw.githubusercontent.com/yichahucha/surge/master/tb_price_lite.js, tag=淘宝比价2 Lite(通知版)
 
-hostname = api.weibo.cn,mapi.weibo.com,*.uve.weibo.com,trade-acs.m.taobao.com,api.m.jd.com,ios.prod.ftl.netflix.com
+hostname = api.weibo.cn,mapi.weibo.com,*.uve.weibo.com,trade-acs.m.taobao.com,api.m.jd.com,ios-h2.prod.ftl.netflix.com


### PR DESCRIPTION
显示价格信息的同时增加京粉转链，如转链成功可点击通知跳转。  
若用户未使用京东系脚本（即未保存 Cookie）或未注册京粉，将自动关闭此功能。  
在商品未推广无返利时，通知为正常的比价信息，且无点击跳转。  
默认配置为使用京东系脚本第一个 Cookie，并在京东、京喜、京东健康浏览商品时点击通知自动跳转至相同软件，并获取京粉返利；在京东极速版浏览时，点击通知将会跳转至默认浏览器（Safari）。  
用户可在 BoxJs 中订阅 `jf_boxjs.json` 进行配置的更改，也可直接下载脚本进行本地更改。  
注：由于京东极速版 URL Scheme 问题，即使在 BoxJs 中更改为跳转京东极速版 app，也需要先加入购物车返回再结账，否则无法使用极速版优惠券。